### PR TITLE
Use absolute path so scripts run from other locations can find FFMPEG.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -21,4 +21,4 @@ curl -L --silent $DOWNLOAD_URL | tar xJ --strip-components=1
 echo "exporting PATH" | indent
 PROFILE_PATH="$BUILD_DIR/.profile.d/ffmpeg.sh"
 mkdir -p $(dirname $PROFILE_PATH)
-echo 'export PATH="$PATH:vendor/ffmpeg"' >> $PROFILE_PATH
+echo 'export PATH="$PATH:${HOME}/vendor/ffmpeg"' >> $PROFILE_PATH


### PR DESCRIPTION
I encountered difficulties using worker scripts that expected to just be able to run a bare `command` and find it in the `$PATH` — the relative path entry this buildpack creates means that scripts not run from `$HOME` (currently `/app` on Heroku) will not find the `ffmpeg` binary.

This change makes the added `$PATH` entry an absolute path, assuming `$HOME` is (which it should be).