### PR TITLE
Fail build on any error

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 indent() {
   sed -u 's/^/       /'
 }


### PR DESCRIPTION
Currently if there is some error in the compile script during release, the build will succeed however ffmpeg will not be available.

This PR should force a failed build in the case some error like the host being down occurs.