### PR TITLE
Update usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,12 @@ Unlike other build packs, I never compile anything.
 
 ## Usage
 
-Add the following to your `.buildpacks`:
+Run the following from the heroku command line:
 
 ```
-https://github.com/jonathanong/heroku-buildpack-ffmpeg-latest.git
+heroku buildpacks:add --index 1 https://github.com/jonathanong/heroku-buildpack-ffmpeg-latest.git
 ```
 
-Or run the following from the heroku command line:
-
-```
-heroku buildpacks:add https://github.com/jonathanong/heroku-buildpack-ffmpeg-latest.git
-```
+Note: This buildpack should be added before the main language buildpack (by using `--index 1`),
+since the application process types are calculated from the last buildpack in the list if no
+`Procfile` is specified.


### PR DESCRIPTION
Since:
* `.buildpacks` is no longer used now that Heroku supports multi-buildpack natively.
* without the `--index 1`, this buildpack gets added to the end of the buildpacks list rather than the start, which for apps relying on automatic process type detection (ie: they don't have an explicit `Procfile`) prevent the main language buildpack from defining them.

Fixes #28.