### PR TITLE
Read FFMPEG_DOWNLOAD_URL env var

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -20,6 +20,8 @@ output() {
 header "Installing ffmpeg"
 
 BUILD_DIR=${1:-}
+CACHE_DIR=${2:-}
+ENV_DIR=${3:-}
 VENDOR_DIR="vendor"
 FFMPEG_ARCHIVE_NAME="ffmpeg.tar.xz"
 
@@ -28,6 +30,10 @@ mkdir -p $VENDOR_DIR
 cd $VENDOR_DIR
 mkdir -p ffmpeg
 cd ffmpeg
+
+if [[ -d "$ENV_DIR" && -f "$ENV_DIR/FFMPEG_DOWNLOAD_URL" ]]; then
+    FFMPEG_DOWNLOAD_URL="$(cat "$ENV_DIR/FFMPEG_DOWNLOAD_URL")"
+fi
 
 if [[ -z $FFMPEG_DOWNLOAD_URL ]]; then
   echo "Variable FFMPEG_DOWNLOAD_URL isn't set, using default value" | output


### PR DESCRIPTION
The documentation mentions that we can set a custom download URL by setting the variable FFMPEG_DOWNLOAD_URL.

However, the config variable is being ignored, because the application config vars are [passed to the buildpack as an argument, not set in the environment](https://devcenter.heroku.com/articles/buildpack-api#bin-compile).

