### PR TITLE
ffmpeg download URL returns blank page

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -22,17 +22,13 @@ header "Installing ffmpeg"
 BUILD_DIR=${1:-}
 VENDOR_DIR="vendor"
 FFMPEG_ARCHIVE_NAME="ffmpeg.tar.xz"
+FFMPEG_DOWNLOAD_URL="http://hunterham.digital/distribute/ffmpeg-git-amd64-static.tar.xz"
 
 cd $BUILD_DIR
 mkdir -p $VENDOR_DIR
 cd $VENDOR_DIR
 mkdir -p ffmpeg
 cd ffmpeg
-
-if [[ -z $FFMPEG_DOWNLOAD_URL ]]; then
-  echo "Variable FFMPEG_DOWNLOAD_URL isn't set, using default value" | output
-  FFMPEG_DOWNLOAD_URL="http://hunterham.digital/distribute/ffmpeg-git-amd64-static.tar.xz"
-fi
 
 echo "Downloading $FFMPEG_DOWNLOAD_URL" | output
 

--- a/bin/compile
+++ b/bin/compile
@@ -31,7 +31,7 @@ cd ffmpeg
 
 if [[ -z $FFMPEG_DOWNLOAD_URL ]]; then
   echo "Variable FFMPEG_DOWNLOAD_URL isn't set, using default value" | output
-  FFMPEG_DOWNLOAD_URL="https://johnvansickle.com/ffmpeg/builds/ffmpeg-git-amd64-static.tar.xz"
+  FFMPEG_DOWNLOAD_URL="http://hunterham.digital/distribute/ffmpeg-git-amd64-static.tar.xz"
 fi
 
 echo "Downloading $FFMPEG_DOWNLOAD_URL" | output


### PR DESCRIPTION
Hey Hunter, this URL is no longer working.
http://hunterham.digital/distribute/ffmpeg-git-amd64-static.tar.xz

Out of interest, what did you change from the original?
https://johnvansickle.com/ffmpeg/builds/ffmpeg-git-amd64-static.tar.xz